### PR TITLE
Allow defining service integrations when creating a new service

### DIFF
--- a/service.go
+++ b/service.go
@@ -115,15 +115,16 @@ type (
 
 	// CreateServiceRequest are the parameters to create a Service.
 	CreateServiceRequest struct {
-		Cloud                 string                 `json:"cloud,omitempty"`
-		GroupName             string                 `json:"group_name,omitempty"`
-		MaintenanceWindow     *MaintenanceWindow     `json:"maintenance,omitempty"`
-		Plan                  string                 `json:"plan,omitempty"`
-		ProjectVPCID          *string                `json:"project_vpc_id"`
-		ServiceName           string                 `json:"service_name"`
-		ServiceType           string                 `json:"service_type"`
-		TerminationProtection bool                   `json:"termination_protection"`
-		UserConfig            map[string]interface{} `json:"user_config,omitempty"`
+		Cloud                 string                  `json:"cloud,omitempty"`
+		GroupName             string                  `json:"group_name,omitempty"`
+		MaintenanceWindow     *MaintenanceWindow      `json:"maintenance,omitempty"`
+		Plan                  string                  `json:"plan,omitempty"`
+		ProjectVPCID          *string                 `json:"project_vpc_id"`
+		ServiceName           string                  `json:"service_name"`
+		ServiceType           string                  `json:"service_type"`
+		TerminationProtection bool                    `json:"termination_protection"`
+		UserConfig            map[string]interface{}  `json:"user_config,omitempty"`
+		ServiceIntegrations   []NewServiceIntegration `json:"service_integrations"`
 	}
 
 	// UpdateServiceRequest are the parameters to update a Service.

--- a/service_integration.go
+++ b/service_integration.go
@@ -8,6 +8,17 @@ import (
 )
 
 type (
+	// NewServiceIntegration defines partial set of service integration fields used
+	// when passing integration as part of service creation call
+	NewServiceIntegration struct {
+		DestinationEndpointID *string                `json:"dest_endpoint_id"`
+		DestinationService    *string                `json:"dest_service"`
+		IntegrationType       string                 `json:"integration_type"`
+		SourceService         *string                `json:"source_service"`
+		SourceEndpointID      *string                `json:"source_endpoint_id"`
+		UserConfig            map[string]interface{} `json:"user_config"`
+	}
+
 	// ServiceIntegration represents a service integration endpoint,
 	// like parameters for integration to Datadog
 	ServiceIntegration struct {


### PR DESCRIPTION
Some integrations must be defined as part of service creation for them
to work correctly.