### PR TITLE
Add service integrations to service

### DIFF
--- a/service.go
+++ b/service.go
@@ -32,6 +32,7 @@ type (
 		ConnectionInfo        ConnectionInfo         `json:"connection_info"`
 		TerminationProtection bool                   `json:"termination_protection"`
 		MaintenanceWindow     MaintenanceWindow      `json:"maintenance"`
+		Integrations          []*ServiceIntegration  `json:"service_integrations"`
 	}
 
 	// Backup represents an individual backup of service data on Aiven


### PR DESCRIPTION
In the API, when making an API call to get a service, or list services for a project the service integrations are returned for a given service, in the JSON response, under the key `service_integrations`.

The service integrations are currently present in the response, but not in the struct returned by `client.Services.List` or `client.Services.Get`.

I've chosen to call it `Integrations` even though the key name in the API response is `service_integrations` because `Integrations` is consistent with `service_uri` ➡️ `URI`