### PR TITLE
Kafka connector response Task type fixed

### DIFF
--- a/kafka_connector.go
+++ b/kafka_connector.go
@@ -20,7 +20,7 @@ type (
 	// KafkaConnectorTask represents Kafka Connector Task
 	KafkaConnectorTask struct {
 		Connector string
-		Task      string
+		Task      int
 	}
 
 	// KafkaConnectorPlugin represents Kafka Connector Plugin


### PR DESCRIPTION
Kafka Connectors response representation in code does not match the actual API JSON response. `KafkaConnectorTask.Connectors.Tasks.Task `is a number in API JSON Response but has the string type in the code. 