### PR TITLE
Kafka schema global configuration PUT request changes

### DIFF
--- a/kafka_schemas.go
+++ b/kafka_schemas.go
@@ -18,13 +18,19 @@ type (
 
 	// KafkaSchemaConfig represents Aiven Kafka Schema Configuration options
 	KafkaSchemaConfig struct {
-		CompatibilityLevel string `json:"compatibilityLevel"`
+		CompatibilityLevel string `json:"compatibility"`
+	}
+
+	// KafkaSchemaConfigUpdateResponse represents the PUT method response from Aiven Kafka Schema Configuration endpoint
+	KafkaSchemaConfigUpdateResponse struct {
+		APIResponse
+		KafkaSchemaConfig
 	}
 
 	// KafkaSchemaConfigResponse represents the response from Aiven Kafka Schema Configuration endpoint
 	KafkaSchemaConfigResponse struct {
 		APIResponse
-		KafkaSchemaConfig
+		CompatibilityLevel string `json:"compatibilityLevel"`
 	}
 
 	// KafkaSchemaSubjects represents a list of Aiven Kafka Schema subjects
@@ -68,14 +74,14 @@ type (
 )
 
 // Update updates new Kafka Schema config entry
-func (h *KafkaGlobalSchemaConfigHandler) Update(project, service string, c KafkaSchemaConfig) (*KafkaSchemaConfigResponse, error) {
+func (h *KafkaGlobalSchemaConfigHandler) Update(project, service string, c KafkaSchemaConfig) (*KafkaSchemaConfigUpdateResponse, error) {
 	path := buildPath("project", project, "service", service, "kafka", "schema", "config")
 	bts, err := h.client.doPutRequest(path, c)
 	if err != nil {
 		return nil, err
 	}
 
-	var r KafkaSchemaConfigResponse
+	var r KafkaSchemaConfigUpdateResponse
 	errR := checkAPIResponse(bts, &r)
 
 	return &r, errR

--- a/kafka_schemas_test.go
+++ b/kafka_schemas_test.go
@@ -35,15 +35,29 @@ func setupKafkaSchemasTestCase(t *testing.T) (*Client, func(t *testing.T)) {
 
 		// config
 		if r.URL.Path == "/project/test-pr/service/test-sr/kafka/schema/config" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			err := json.NewEncoder(w).Encode(KafkaSchemaConfigResponse{
-				APIResponse{},
-				KafkaSchemaConfig{CompatibilityLevel: "FULL"},
-			})
+			if r.Method == "PUT" {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				err := json.NewEncoder(w).Encode(KafkaSchemaConfigUpdateResponse{
+					APIResponse{},
+					KafkaSchemaConfig{CompatibilityLevel: "FULL"},
+				})
 
-			if err != nil {
-				t.Error(err)
+				if err != nil {
+					t.Error(err)
+				}
+			}
+
+			if r.Method == "GET" {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				err := json.NewEncoder(w).Encode(KafkaSchemaConfigResponse{
+					CompatibilityLevel: "FULL",
+				})
+
+				if err != nil {
+					t.Error(err)
+				}
 			}
 
 			return
@@ -54,8 +68,7 @@ func setupKafkaSchemasTestCase(t *testing.T) (*Client, func(t *testing.T)) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			err := json.NewEncoder(w).Encode(KafkaSchemaConfigResponse{
-				APIResponse{},
-				KafkaSchemaConfig{CompatibilityLevel: "FULL"},
+				CompatibilityLevel: "FULL",
 			})
 
 			if err != nil {
@@ -219,7 +232,7 @@ func TestKafkaGlobalSchemaConfigHandler_Update(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		want    *KafkaSchemaConfigResponse
+		want    *KafkaSchemaConfigUpdateResponse
 		wantErr bool
 	}{
 		{
@@ -232,7 +245,7 @@ func TestKafkaGlobalSchemaConfigHandler_Update(t *testing.T) {
 					CompatibilityLevel: "FULL",
 				},
 			},
-			&KafkaSchemaConfigResponse{
+			&KafkaSchemaConfigUpdateResponse{
 				APIResponse: APIResponse{},
 				KafkaSchemaConfig: KafkaSchemaConfig{
 					CompatibilityLevel: "FULL",
@@ -408,10 +421,8 @@ func TestKafkaGlobalSchemaConfigHandler_Get(t *testing.T) {
 				service: "test-sr",
 			},
 			&KafkaSchemaConfigResponse{
-				APIResponse: APIResponse{},
-				KafkaSchemaConfig: KafkaSchemaConfig{
-					CompatibilityLevel: "FULL",
-				},
+				APIResponse:        APIResponse{},
+				CompatibilityLevel: "FULL",
 			},
 			false,
 		},


### PR DESCRIPTION
Aiven API Kafka Schema Global configuration GET and PUT methods have different response signatures. Get method retrieves ```{"compatibilityLevel":"FULL"}``` and PUT method expect and retrieves back ```{"compatibility":"FULL"}``` **compatibility** not **compatibilityLevel**