### PR TITLE
Fix project account

### DIFF
--- a/accounts_acc_test.go
+++ b/accounts_acc_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Accounts", func() {
 	)
 
 	BeforeEach(func() {
-		accountName = "test-acc-account#" + strconv.Itoa(rand.Int())
+		accountName = "test-acc-account" + strconv.Itoa(rand.Int())
 		account, err = client.Accounts.Create(Account{Name: accountName})
 	})
 
@@ -45,7 +45,7 @@ var _ = Describe("Accounts", func() {
 			if account == nil {
 				Fail("account is nil")
 			}
-			teamName = "test-acc-team#" + strconv.Itoa(rand.Int())
+			teamName = "test-acc-team" + strconv.Itoa(rand.Int())
 			team, errT = client.AccountTeams.Create(account.Account.Id, AccountTeam{
 				Name: teamName,
 			})

--- a/project.go
+++ b/project.go
@@ -38,7 +38,7 @@ type (
 		CopyFromProject  string           `json:"copy_from_project,omitempty"`
 		CountryCode      *string          `json:"country_code,omitempty"`
 		Project          string           `json:"project"`
-		AccountId        string           `json:"account_id"`
+		AccountId        string           `json:"account_id,omitempty"`
 		TechnicalEmails  *[]*ContactEmail `json:"tech_emails,omitempty"`
 	}
 

--- a/project_acc_test.go
+++ b/project_acc_test.go
@@ -1,0 +1,45 @@
+package aiven
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"math/rand"
+	"strconv"
+)
+
+var _ = Describe("Projects", func() {
+	var (
+		projectName string
+		project     *Project
+		err         error
+	)
+
+	BeforeEach(func() {
+		projectName = "test-acc-pr" + strconv.Itoa(rand.Int())
+		project, err = client.Projects.Create(CreateProjectRequest{
+			Project: projectName,
+		})
+	})
+
+	Context("Create new project", func() {
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should populate fields properly", func() {
+			Expect(project).NotTo(BeNil())
+
+			if project != nil {
+				Expect(project.Name).NotTo(BeEmpty())
+				Expect(project.AccountId).To(BeEmpty())
+			}
+		})
+	})
+
+	AfterEach(func() {
+		err = client.Projects.Delete(projectName)
+		if err != nil {
+			Fail("cannot delete project : " + err.Error())
+		}
+	})
+})


### PR DESCRIPTION
- Account Id property should be optional and omitted if empty, API expects this behaviour, otherwise impossible to create new projects since it tries to link a project with an empty account. 
- Also, in the new version of Aiven API name for the account and team account should be alphanumeric and do not support special symbols.