### PR TITLE
acceptance tests use an existing project

### DIFF
--- a/aiven_go_client_suite_test.go
+++ b/aiven_go_client_suite_test.go
@@ -35,9 +35,9 @@ var _ = BeforeSuite(func() {
 		Fail("cannot create Aiven API client, `AIVEN_TOKEN` is required")
 	}
 
-	cardId := os.Getenv("AIVEN_CARD_ID")
+	cardId := os.Getenv("AIVEN_PROJECT_NAME")
 	if cardId == "" {
-		Fail("cannot create Aiven API client, `AIVEN_CARD_ID` is required")
+		Fail("cannot create Aiven API client, `AIVEN_PROJECT_NAME` is required")
 	}
 
 	client, err = NewTokenClient(

--- a/mirrormaker_replication_flow_acc_test.go
+++ b/mirrormaker_replication_flow_acc_test.go
@@ -16,14 +16,11 @@ var _ = Describe("MirrorMaker 2 Replication flow", func() {
 	)
 
 	BeforeEach(func() {
-		projectName = "test-acc-pr-mm-" + strconv.Itoa(rand.Int())
-		project, err = client.Projects.Create(CreateProjectRequest{
-			Project: projectName,
-			CardID:  os.Getenv("AIVEN_CARD_ID"),
-		})
+		projectName = os.Getenv("AIVEN_PROJECT_NAME")
+		project, err = client.Projects.Get(projectName)
 	})
 
-	Context("Create new project", func() {
+	Context("Get a project", func() {
 		It("should not error", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -139,12 +136,5 @@ var _ = Describe("MirrorMaker 2 Replication flow", func() {
 				Fail("cannot delete service:" + errD.Error())
 			}
 		})
-	})
-
-	AfterEach(func() {
-		err = client.Projects.Delete(projectName)
-		if err != nil {
-			Fail("cannot delete project : " + err.Error())
-		}
 	})
 })


### PR DESCRIPTION
Use an existing project for acceptance test instead of creating a new one each time during the run.