### PR TITLE
fix project user get method

### DIFF
--- a/project_user.go
+++ b/project_user.go
@@ -12,6 +12,8 @@ type (
 		Email          string   `json:"user_email"`
 		RealName       string   `json:"real_name"`
 		MemberType     string   `json:"member_type"`
+		TeamId         string   `json:"team_id"`
+		TeamName       string   `json:"team_name"`
 		BillingContact bool     `json:"billing_contact"`
 		AuthMethods    []string `json:"auth"`
 		CreateTime     string   `json:"create_time"`
@@ -69,7 +71,7 @@ func (h *ProjectUsersHandler) Get(project, email string) (*ProjectUser, *Project
 	}
 
 	for _, user := range users {
-		if user.Email == email {
+		if user.Email == email && user.TeamId == "" {
 			return user, nil, nil
 		}
 	}


### PR DESCRIPTION
API retrieves a list of all project users, including account team members, when a team is associated with the project. Unfortunately, this makes a get method unreliable when a project user and account team member has the same email address. Therefore we filter out all account team members from the list by checking team_id fields. Account team members do have a separate API endpoint and can be excluded from project users search.