### PR TITLE
Add method on ProjectsHandler to get event logs

### DIFF
--- a/project.go
+++ b/project.go
@@ -81,6 +81,21 @@ type (
 		APIResponse
 		Projects []*Project `json:"projects"`
 	}
+
+	// ProjectEventLogEntriesResponse is the response from Aiven for project event log entries
+	ProjectEventLogEntriesResponse struct {
+		APIResponse
+		Events []*ProjectEvent `json:"events"`
+	}
+
+	// ProjectEvent represents a project event log entry
+	ProjectEvent struct {
+		Actor       string `json:"actor"`
+		EventDesc   string `json:"event_desc"`
+		EventType   string `json:"event_type"`
+		ServiceName string `json:"service_name"`
+		Time        string `json:"time"`
+	}
 )
 
 // ContactEmailFromStringSlice creates []*ContactEmail from string slice
@@ -175,4 +190,17 @@ func (h *ProjectsHandler) List() ([]*Project, error) {
 	errR := checkAPIResponse(bts, &r)
 
 	return r.Projects, errR
+}
+
+// EventLog Get project event log entries
+func (h *ProjectsHandler) GetEventLog(project string) ([]*ProjectEvent, error) {
+	bts, err := h.client.doGetRequest(buildPath("project", project, "events"), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var r ProjectEventLogEntriesResponse
+	errR := checkAPIResponse(bts, &r)
+
+	return r.Events, errR
 }

--- a/project_acc_test.go
+++ b/project_acc_test.go
@@ -72,6 +72,18 @@ var _ = Describe("Projects", func() {
 		})
 	})
 
+	Context("Get project event logs", func() {
+		It("should be event logs", func() {
+			events, logErr := client.Projects.GetEventLog(projectName)
+			Expect(logErr).To(BeNil())
+			Expect(events).ToNot(BeNil())
+			Expect(events).Should(Not(BeEmpty()))
+			for _, event := range events {
+				Expect(event).NotTo(BeNil())
+			}
+		})
+	})
+
 	AfterEach(func() {
 		err = client.Projects.Delete(projectName)
 		if err != nil {


### PR DESCRIPTION
I need to be able to get the event logs for a given project ref: https://api.aiven.io/doc/#operation/ProjectGetEventLogs.