### PR TITLE
Fix AccessControl struct fields should be omitted if empty

### DIFF
--- a/service_user.go
+++ b/service_user.go
@@ -26,11 +26,11 @@ type (
 	}
 
 	AccessControl struct {
-		RedisACLCategories       []string `json:"redis_acl_categories"`
-		RedisACLCommands         []string `json:"redis_acl_commands"`
-		RedisACLKeys             []string `json:"redis_acl_keys"`
-		RedisACLChannels         []string `json:"redis_acl_channels"`
-		PostgresAllowReplication bool     `json:"pg_allow_replication"`
+		RedisACLCategories       *[]string `json:"redis_acl_categories,omitempty"`
+		RedisACLCommands         *[]string `json:"redis_acl_commands,omitempty"`
+		RedisACLKeys             *[]string `json:"redis_acl_keys,omitempty"`
+		RedisACLChannels         *[]string `json:"redis_acl_channels,omitempty"`
+		PostgresAllowReplication *bool     `json:"pg_allow_replication,omitempty"`
 	}
 
 	// ServiceUsersHandler is the client that interacts with the ServiceUsers

--- a/service_user.go
+++ b/service_user.go
@@ -26,11 +26,11 @@ type (
 	}
 
 	AccessControl struct {
-		RedisACLCategories       *[]string `json:"redis_acl_categories,omitempty"`
-		RedisACLCommands         *[]string `json:"redis_acl_commands,omitempty"`
-		RedisACLKeys             *[]string `json:"redis_acl_keys,omitempty"`
-		RedisACLChannels         *[]string `json:"redis_acl_channels,omitempty"`
-		PostgresAllowReplication *bool     `json:"pg_allow_replication,omitempty"`
+		RedisACLCategories       []string `json:"redis_acl_categories,omitempty"`
+		RedisACLCommands         []string `json:"redis_acl_commands,omitempty"`
+		RedisACLKeys             []string `json:"redis_acl_keys,omitempty"`
+		RedisACLChannels         []string `json:"redis_acl_channels,omitempty"`
+		PostgresAllowReplication *bool    `json:"pg_allow_replication,omitempty"`
 	}
 
 	// ServiceUsersHandler is the client that interacts with the ServiceUsers


### PR DESCRIPTION
When updating the AccessControl of a redis user and empty fields are not omitted we get a 400 error from aiven API.
Sorry for the multiple PRs.