### PR TITLE
Make username an optional field on ConnectionPool requests

### DIFF
--- a/connection_pool.go
+++ b/connection_pool.go
@@ -15,19 +15,19 @@ type (
 
 	// CreateConnectionPoolRequest are the parameters used to create a connection pool entry.
 	CreateConnectionPoolRequest struct {
-		Database string `json:"database"`
-		PoolMode string `json:"pool_mode"`
-		PoolName string `json:"pool_name"`
-		PoolSize int    `json:"pool_size"`
-		Username string `json:"username,omitempty"`
+		Database string  `json:"database"`
+		PoolMode string  `json:"pool_mode"`
+		PoolName string  `json:"pool_name"`
+		PoolSize int     `json:"pool_size"`
+		Username *string `json:"username,omitempty"`
 	}
 
 	// UpdateConnectionPoolRequest are the parameters used to update a connection pool entry.
 	UpdateConnectionPoolRequest struct {
-		Database string `json:"database"`
-		PoolMode string `json:"pool_mode"`
-		PoolSize int    `json:"pool_size"`
-		Username string `json:"username,omitempty"`
+		Database string  `json:"database"`
+		PoolMode string  `json:"pool_mode"`
+		PoolSize int     `json:"pool_size"`
+		Username *string `json:"username,omitempty"`
 	}
 )
 

--- a/connection_pool.go
+++ b/connection_pool.go
@@ -19,7 +19,7 @@ type (
 		PoolMode string `json:"pool_mode"`
 		PoolName string `json:"pool_name"`
 		PoolSize int    `json:"pool_size"`
-		Username string `json:"username"`
+		Username string `json:"username,omitempty"`
 	}
 
 	// UpdateConnectionPoolRequest are the parameters used to update a connection pool entry.
@@ -27,7 +27,7 @@ type (
 		Database string `json:"database"`
 		PoolMode string `json:"pool_mode"`
 		PoolSize int    `json:"pool_size"`
-		Username string `json:"username"`
+		Username string `json:"username,omitempty"`
 	}
 )
 


### PR DESCRIPTION
This is currently a required field on the request structs while the API
does not require it.  Omitting it results in the pool using the
'Reuse inbound user', like the UI defaults to.