### PR TITLE
adds the m3_group in the service_user.access_control struct

### DIFF
--- a/service_user.go
+++ b/service_user.go
@@ -26,6 +26,7 @@ type (
 	}
 
 	AccessControl struct {
+		M3Group                  *string  `json:"m3_group,omitempty"`
 		RedisACLCategories       []string `json:"redis_acl_categories,omitempty"`
 		RedisACLCommands         []string `json:"redis_acl_commands,omitempty"`
 		RedisACLKeys             []string `json:"redis_acl_keys,omitempty"`


### PR DESCRIPTION
This PR is to adds the m3_group on the service user.
I did not set omitempty on it since if we want to delete the group, we need to explicitly set a null on it. Tried with a curl on a PG service, looks like the explicit null does not break the update a user on other engines.