### PR TITLE
Add support to create billing group by copying from an existing one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Folders
 bin
+
+# Editor
+.vscode

--- a/billing_group.go
+++ b/billing_group.go
@@ -9,19 +9,20 @@ type (
 
 	// BillingGroupRequest  is the request from Aiven for the billing group endpoints.
 	BillingGroupRequest struct {
-		BillingGroupName string          `json:"billing_group_name,omitempty"`
-		AccountId        *string         `json:"account_id,omitempty"`
-		CardId           *string         `json:"card_id,omitempty"`
-		VatId            *string         `json:"vat_id,omitempty"`
-		BillingCurrency  *string         `json:"billing_currency,omitempty"`
-		BillingExtraText *string         `json:"billing_extra_text,omitempty"`
-		BillingEmails    []*ContactEmail `json:"billing_emails,omitempty"`
-		Company          *string         `json:"company,omitempty"`
-		AddressLines     []string        `json:"address_lines,omitempty"`
-		CountryCode      *string         `json:"country_code,omitempty"`
-		City             *string         `json:"city,omitempty"`
-		State            *string         `json:"state,omitempty"`
-		ZipCode          *string         `json:"zip_code,omitempty"`
+		BillingGroupName     string          `json:"billing_group_name,omitempty"`
+		AccountId            *string         `json:"account_id,omitempty"`
+		CardId               *string         `json:"card_id,omitempty"`
+		VatId                *string         `json:"vat_id,omitempty"`
+		BillingCurrency      *string         `json:"billing_currency,omitempty"`
+		BillingExtraText     *string         `json:"billing_extra_text,omitempty"`
+		BillingEmails        []*ContactEmail `json:"billing_emails,omitempty"`
+		Company              *string         `json:"company,omitempty"`
+		AddressLines         []string        `json:"address_lines,omitempty"`
+		CountryCode          *string         `json:"country_code,omitempty"`
+		City                 *string         `json:"city,omitempty"`
+		State                *string         `json:"state,omitempty"`
+		ZipCode              *string         `json:"zip_code,omitempty"`
+		CopyFromBillingGroup *string         `json:"copy_from_billing_group,omitempty"`
 	}
 
 	// BillingGroupHandler is the client that interacts with billing groups on Aiven

--- a/billing_group_acc_test.go
+++ b/billing_group_acc_test.go
@@ -1,16 +1,18 @@
 package aiven
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"math/rand"
 	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("BillingGroup", func() {
 	var (
 		billingGName string
 		billingG     *BillingGroup
+		copiedBG     *BillingGroup
 		err          error
 	)
 
@@ -97,6 +99,23 @@ var _ = Describe("BillingGroup", func() {
 			list, err := client.BillingGroup.ListAll()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(list).NotTo(BeEmpty())
+		})
+
+		It("create billing group by copy from an existing one", func() {
+			billingGName = "copy-from-" + billingG.BillingGroupName
+			copiedBG, err = client.BillingGroup.Create(BillingGroupRequest{
+				BillingGroupName:     billingGName,
+				CopyFromBillingGroup: ToStringPointer(billingG.Id),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(copiedBG.Id).NotTo(BeNil())
+			Expect(copiedBG.Id).NotTo(Equal(billingG.Id))
+			Expect(copiedBG.Company).To(Equal(billingG.Company))
+			Expect(copiedBG.AddressLines).To(Equal(billingG.AddressLines))
+			Expect(copiedBG.CountryCode).To(Equal(billingG.CountryCode))
+			Expect(copiedBG.City).To(Equal(billingG.City))
+			Expect(copiedBG.ZipCode).To(Equal(billingG.ZipCode))
+			Expect(copiedBG.BillingCurrency).To(Equal(billingG.BillingCurrency))
 		})
 	})
 


### PR DESCRIPTION
Allow creating a new billing group by copying the data from an existing one.