### PR TITLE
Add offset_syncs_topic_location to mirrormaker payloads.

### DIFF
--- a/mirrormaker_replication_flow.go
+++ b/mirrormaker_replication_flow.go
@@ -12,6 +12,7 @@ type (
 	// ReplicationFlow a replication flow entity
 	ReplicationFlow struct {
 		Enabled                         bool     `json:"enabled"`
+		OffsetSyncsTopicLocation        string   `json:"offset_syncs_topic_location,omitempty"`
 		SourceCluster                   string   `json:"source_cluster,omitempty"`
 		TargetCluster                   string   `json:"target_cluster,omitempty"`
 		ReplicationPolicyClass          string   `json:"replication_policy_class"`

--- a/mirrormaker_replication_flow_test.go
+++ b/mirrormaker_replication_flow_test.go
@@ -42,6 +42,7 @@ func setupMirrormakerReplicationFlowTestCase(t *testing.T) (*Client, func(t *tes
 					"message": "Completed",
 					"replication_flows": [{
 						"enabled": true,
+						"offset_syncs_topic_location": "source",
 						"source_cluster": "kafka-sc",
 						"target_cluster": "kafka-tc",
 						"topics": [
@@ -68,6 +69,7 @@ func setupMirrormakerReplicationFlowTestCase(t *testing.T) (*Client, func(t *tes
 				{
 					"replication_flow": {
 						"enabled": true,
+						"offset_syncs_topic_location": "source",
 						"source_cluster": "kafka-sc",
 						"target_cluster": "kafka-tc",
 						"topics": [
@@ -207,9 +209,10 @@ func TestMirrorMakerReplicationFlowHandler_Update(t *testing.T) {
 			},
 			&MirrorMakerReplicationFlowResponse{
 				ReplicationFlow: ReplicationFlow{
-					Enabled:       true,
-					SourceCluster: "kafka-sc",
-					TargetCluster: "kafka-tc",
+					Enabled:                  true,
+					OffsetSyncsTopicLocation: "source",
+					SourceCluster:            "kafka-sc",
+					TargetCluster:            "kafka-tc",
 					Topics: []string{
 						".*",
 					},
@@ -274,9 +277,10 @@ func TestMirrorMakerReplicationFlowHandler_List(t *testing.T) {
 				},
 				ReplicationFlows: []ReplicationFlow{
 					{
-						Enabled:       true,
-						SourceCluster: "kafka-sc",
-						TargetCluster: "kafka-tc",
+						Enabled:                  true,
+						OffsetSyncsTopicLocation: "source",
+						SourceCluster:            "kafka-sc",
+						TargetCluster:            "kafka-tc",
 						Topics: []string{
 							".*",
 						},
@@ -384,9 +388,10 @@ func TestMirrorMakerReplicationFlowHandler_Get(t *testing.T) {
 			},
 			&MirrorMakerReplicationFlowResponse{
 				ReplicationFlow: ReplicationFlow{
-					Enabled:       true,
-					SourceCluster: "kafka-sc",
-					TargetCluster: "kafka-tc",
+					Enabled:                  true,
+					OffsetSyncsTopicLocation: "source",
+					SourceCluster:            "kafka-sc",
+					TargetCluster:            "kafka-tc",
 					Topics: []string{
 						".*",
 					},


### PR DESCRIPTION
Not much to this PR apart from adding the field and adding some data to the test payloads. The docs indicate it's not a mandatory field, but let me know if you want more specific tests around CRUD operations of this particular field.