### PR TITLE
make UpdateServiceIntegrationRequest.UserConfig required

### DIFF
--- a/service_integration.go
+++ b/service_integration.go
@@ -52,7 +52,7 @@ type (
 
 	// UpdateServiceIntegrationRequest are the parameters to update a Service Integration.
 	UpdateServiceIntegrationRequest struct {
-		UserConfig map[string]interface{} `json:"user_config,omitempty"`
+		UserConfig map[string]interface{} `json:"user_config"`
 	}
 
 	// ServiceIntegrationResponse represents the response from Aiven


### PR DESCRIPTION
user_config field is actually required by API https://api.aiven.io/doc/#operation/ServiceIntegrationUpdate