### PR TITLE
fix AccountAuthenticationUpdate method

### DIFF
--- a/account_authentications.go
+++ b/account_authentications.go
@@ -11,32 +11,65 @@ type (
 		client *Client
 	}
 
-	// AccountAuthenticationMethod represents account authentication method
+	// AccountAuthenticationMethodCreate request object for AccountAuthenticationMethodCreate
+	// https://api.aiven.io/doc/#operation/AccountAuthenticationMethodCreate
+	AccountAuthenticationMethodCreate struct {
+		AuthenticationMethodName string            `json:"authentication_method_name"`
+		AuthenticationMethodType string            `json:"authentication_method_type"`
+		AutoJoinTeamID           string            `json:"auto_join_team_id,omitempty"`
+		SAMLCertificate          string            `json:"saml_certificate,omitempty"`
+		SAMLDigestAlgorithm      string            `json:"saml_digest_algorithm,omitempty"`
+		SAMLEntityID             string            `json:"saml_entity_id,omitempty"`
+		SAMLFieldMapping         *SAMLFieldMapping `json:"saml_field_mapping,omitempty"`
+		SAMLIdpLoginAllowed      bool              `json:"saml_idp_login_allowed,omitempty"`
+		SAMLIdpURL               string            `json:"saml_idp_url,omitempty"`
+		SAMLSignatureAlgorithm   string            `json:"saml_signature_algorithm,omitempty"`
+		SAMLVariant              string            `json:"saml_variant,omitempty"`
+	}
+
+	// AccountAuthenticationMethodUpdate request object for AccountAuthenticationMethodUpdate
+	// https://api.aiven.io/doc/#operation/AccountAuthenticationMethodUpdate
+	AccountAuthenticationMethodUpdate struct {
+		AuthenticationMethodEnabled bool              `json:"authentication_method_enabled,omitempty"`
+		AuthenticationMethodName    string            `json:"authentication_method_name"`
+		AutoJoinTeamID              string            `json:"auto_join_team_id,omitempty"`
+		SAMLCertificate             string            `json:"saml_certificate,omitempty"`
+		SAMLDigestAlgorithm         string            `json:"saml_digest_algorithm,omitempty"`
+		SAMLEntity                  string            `json:"saml_entity_id,omitempty"`
+		SAMLFieldMapping            *SAMLFieldMapping `json:"saml_field_mapping,omitempty"`
+		SAMLIdpLoginAllowed         bool              `json:"saml_idp_login_allowed,omitempty"`
+		SAMLIdpURL                  string            `json:"saml_idp_url,omitempty"`
+		SAMLSignatureAlgorithm      string            `json:"saml_signature_algorithm,omitempty"`
+		SAMLVariant                 string            `json:"saml_variant,omitempty"`
+	}
+
+	// AccountAuthenticationMethod response object for AccountAuthenticationMethodUpdate
+	// https://api.aiven.io/doc/#operation/AccountAuthenticationMethodUpdate
 	AccountAuthenticationMethod struct {
-		AccountId                     string            `json:"account_id,omitempty"`
-		Enabled                       bool              `json:"authentication_method_enabled,omitempty"`
-		Id                            string            `json:"authentication_method_id,omitempty"`
-		Name                          string            `json:"authentication_method_name"`
-		Type                          string            `json:"authentication_method_type"`
-		AutoJoinTeamId                string            `json:"auto_join_team_id,omitempty"`
-		State                         string            `json:"state,omitempty"`
+		AccountID                     string            `json:"account_id"`
+		AuthenticationMethodEnabled   bool              `json:"authentication_method_enabled"`
+		AuthenticationMethodID        string            `json:"authentication_method_id"`
+		AuthenticationMethodName      string            `json:"authentication_method_name"`
+		AuthenticationMethodType      string            `json:"authentication_method_type"`
+		AutoJoinTeamID                string            `json:"auto_join_team_id"`
+		CreateTime                    *time.Time        `json:"create_time"`
+		DeleteTime                    *time.Time        `json:"delete_time"`
+		SAMLAcsURL                    string            `json:"saml_acs_url,omitempty"`
 		SAMLCertificate               string            `json:"saml_certificate,omitempty"`
+		SAMLCertificateIssuer         string            `json:"saml_certificate_issuer,omitempty"`
+		SAMLCertificateNotValidAfter  string            `json:"saml_certificate_not_valid_after,omitempty"`
+		SAMLCertificateNotValidBefore string            `json:"saml_certificate_not_valid_before,omitempty"`
+		SAMLCertificateSubject        string            `json:"saml_certificate_subject,omitempty"`
 		SAMLDigestAlgorithm           string            `json:"saml_digest_algorithm,omitempty"`
-		SAMLIdpUrl                    string            `json:"saml_idp_url,omitempty"`
-		SAMLEntity                    string            `json:"saml_entity_id,omitempty"`
+		SAMLEntityID                  string            `json:"saml_entity_id,omitempty"`
 		SAMLFieldMapping              *SAMLFieldMapping `json:"saml_field_mapping,omitempty"`
 		SAMLIdpLoginAllowed           bool              `json:"saml_idp_login_allowed,omitempty"`
+		SAMLIdpURL                    string            `json:"saml_idp_url,omitempty"`
+		SAMLMetadataURL               string            `json:"saml_metadata_url,omitempty"`
 		SAMLSignatureAlgorithm        string            `json:"saml_signature_algorithm,omitempty"`
 		SAMLVariant                   string            `json:"saml_variant,omitempty"`
-		SAMLAcsUrl                    string            `json:"saml_acs_url,omitempty"`
-		SAMLMetadataUrl               string            `json:"saml_metadata_url,omitempty"`
-		SAMLCertificateIssuer         string            `json:"saml_certificate_issuer,omitempty"`
-		SAMLCertificateSubject        string            `json:"saml_certificate_subject,omitempty"`
-		SAMLCertificateNotValidAfter  *time.Time        `json:"saml_certificate_not_valid_after,omitempty"`
-		SAMLCertificateNotValidBefore *time.Time        `json:"saml_certificate_not_valid_before,omitempty"`
-		CreateTime                    *time.Time        `json:"create_time,omitempty"`
-		UpdateTime                    *time.Time        `json:"update_time,omitempty"`
-		DeleteTime                    *time.Time        `json:"delete_time,omitempty"`
+		State                         string            `json:"state"`
+		UpdateTime                    *time.Time        `json:"update_time"`
 	}
 
 	SAMLFieldMapping struct {
@@ -47,8 +80,8 @@ type (
 		RealName  string `json:"real_name,omitempty"`
 	}
 
-	// AccountAuthenticationsResponse represents account list of available authentication methods API response
-	AccountAuthenticationsResponse struct {
+	// AccountAuthenticationListResponse represents account list of available authentication methods API response
+	AccountAuthenticationListResponse struct {
 		APIResponse
 		AuthenticationMethods []AccountAuthenticationMethod `json:"authentication_methods"`
 	}
@@ -61,7 +94,7 @@ type (
 )
 
 // List returns a list of all available account authentication methods
-func (h AccountAuthenticationsHandler) List(accountId string) (*AccountAuthenticationsResponse, error) {
+func (h AccountAuthenticationsHandler) List(accountId string) (*AccountAuthenticationListResponse, error) {
 	if accountId == "" {
 		return nil, errors.New("cannot get a list of account authentication methods when account id is empty")
 	}
@@ -72,7 +105,7 @@ func (h AccountAuthenticationsHandler) List(accountId string) (*AccountAuthentic
 		return nil, err
 	}
 
-	var rsp AccountAuthenticationsResponse
+	var rsp AccountAuthenticationListResponse
 	if errR := checkAPIResponse(bts, &rsp); errR != nil {
 		return nil, errR
 	}
@@ -101,7 +134,7 @@ func (h AccountAuthenticationsHandler) Get(accountId, authId string) (*AccountAu
 }
 
 // Create creates an account authentication method
-func (h AccountAuthenticationsHandler) Create(accountId string, a AccountAuthenticationMethod) (*AccountAuthenticationResponse, error) {
+func (h AccountAuthenticationsHandler) Create(accountId string, a AccountAuthenticationMethodCreate) (*AccountAuthenticationResponse, error) {
 	if accountId == "" {
 		return nil, errors.New("cannot create an account authentication method when account id is empty")
 	}
@@ -120,13 +153,13 @@ func (h AccountAuthenticationsHandler) Create(accountId string, a AccountAuthent
 	return &rsp, nil
 }
 
-// Update updates an account authentication method
-func (h AccountAuthenticationsHandler) Update(accountId string, a AccountAuthenticationMethod) (*AccountAuthenticationResponse, error) {
-	if accountId == "" || a.Id == "" {
+// Update updates an account authentication method empty fields are omitted, acts like PATCH
+func (h AccountAuthenticationsHandler) Update(accountId, accountAuthMethID string, a AccountAuthenticationMethodUpdate) (*AccountAuthenticationResponse, error) {
+	if accountId == "" || accountAuthMethID == "" {
 		return nil, errors.New("cannot update an account authentication method when account id or auth id is empty")
 	}
 
-	path := buildPath("account", accountId, "authentication", a.Id)
+	path := buildPath("account", accountId, "authentication", accountAuthMethID)
 	bts, err := h.client.doPutRequest(path, a)
 	if err != nil {
 		return nil, err

--- a/account_authentications_test.go
+++ b/account_authentications_test.go
@@ -35,19 +35,35 @@ func setupAccountAuthenticationsTestCase(t *testing.T) (*Client, func(t *testing
 		if r.URL.Path == "/account/a28707e316df/authentication/am28707eb0055" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			err := json.NewEncoder(w).Encode(AccountAuthenticationResponse{
-				APIResponse: APIResponse{},
-				AuthenticationMethod: AccountAuthenticationMethod{
-					AccountId:  "a28707e316df",
-					Enabled:    true,
-					Id:         "am28707eb0055",
-					Name:       "test",
-					Type:       "saml",
-					State:      "active",
-					CreateTime: getTime(t),
-					UpdateTime: getTime(t),
-				},
-			})
+
+			var err error
+			switch r.Method {
+			case "PUT":
+				err = json.NewEncoder(w).Encode(AccountAuthenticationResponse{
+					APIResponse: APIResponse{},
+					AuthenticationMethod: AccountAuthenticationMethod{
+						AccountID:  "a28707e316df",
+						State:      "active",
+						CreateTime: getTime(t),
+						UpdateTime: getTime(t),
+						DeleteTime: getTime(t),
+					},
+				})
+			default:
+				err = json.NewEncoder(w).Encode(AccountAuthenticationResponse{
+					APIResponse: APIResponse{},
+					AuthenticationMethod: AccountAuthenticationMethod{
+						AccountID:                   "a28707e316df",
+						AuthenticationMethodEnabled: true,
+						AuthenticationMethodName:    "test",
+						AuthenticationMethodType:    "saml",
+						State:                       "active",
+						CreateTime:                  getTime(t),
+						UpdateTime:                  getTime(t),
+						DeleteTime:                  getTime(t),
+					},
+				})
+			}
 
 			if err != nil {
 				t.Error(err)
@@ -62,14 +78,14 @@ func setupAccountAuthenticationsTestCase(t *testing.T) (*Client, func(t *testing
 				err := json.NewEncoder(w).Encode(AccountAuthenticationResponse{
 					APIResponse: APIResponse{},
 					AuthenticationMethod: AccountAuthenticationMethod{
-						AccountId:  "a28707e316df",
-						Enabled:    true,
-						Id:         "am28707eb0055",
-						Name:       "test",
-						Type:       "saml",
-						State:      "active",
-						CreateTime: getTime(t),
-						UpdateTime: getTime(t),
+						AccountID:                   "a28707e316df",
+						AuthenticationMethodEnabled: true,
+						AuthenticationMethodName:    "test",
+						AuthenticationMethodType:    "saml",
+						State:                       "active",
+						CreateTime:                  getTime(t),
+						UpdateTime:                  getTime(t),
+						DeleteTime:                  getTime(t),
 					},
 				})
 
@@ -81,17 +97,18 @@ func setupAccountAuthenticationsTestCase(t *testing.T) (*Client, func(t *testing
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			err := json.NewEncoder(w).Encode(AccountAuthenticationsResponse{
+			err := json.NewEncoder(w).Encode(AccountAuthenticationListResponse{
 				AuthenticationMethods: []AccountAuthenticationMethod{
 					{
-						AccountId:  "a28707e316df",
-						Enabled:    true,
-						Id:         "am28707eb0055",
-						Name:       "Platform authentication",
-						Type:       "internal",
-						State:      "active",
-						CreateTime: getTime(t),
-						UpdateTime: getTime(t),
+						AccountID:                   "a28707e316df",
+						AuthenticationMethodID:      "am28707eb0055",
+						AuthenticationMethodEnabled: true,
+						AuthenticationMethodName:    "Platform authentication",
+						AuthenticationMethodType:    "internal",
+						State:                       "active",
+						CreateTime:                  getTime(t),
+						UpdateTime:                  getTime(t),
+						DeleteTime:                  getTime(t),
 					},
 				},
 			})
@@ -131,25 +148,26 @@ func TestAccountAuthenticationsHandler_List(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		want    *AccountAuthenticationsResponse
+		want    *AccountAuthenticationListResponse
 		wantErr bool
 	}{
 		{
 			"normal",
 			fields{client: c},
 			args{accountId: "a28707e316df"},
-			&AccountAuthenticationsResponse{
+			&AccountAuthenticationListResponse{
 				APIResponse: APIResponse{},
 				AuthenticationMethods: []AccountAuthenticationMethod{
 					{
-						AccountId:  "a28707e316df",
-						Enabled:    true,
-						Id:         "am28707eb0055",
-						Name:       "Platform authentication",
-						Type:       "internal",
-						State:      "active",
-						CreateTime: getTime(t),
-						UpdateTime: getTime(t),
+						AccountID:                   "a28707e316df",
+						AuthenticationMethodEnabled: true,
+						AuthenticationMethodID:      "am28707eb0055",
+						AuthenticationMethodName:    "Platform authentication",
+						AuthenticationMethodType:    "internal",
+						State:                       "active",
+						CreateTime:                  getTime(t),
+						UpdateTime:                  getTime(t),
+						DeleteTime:                  getTime(t),
 					},
 				},
 			},
@@ -188,8 +206,9 @@ func TestAccountAuthenticationsHandler_Create(t *testing.T) {
 		client *Client
 	}
 	type args struct {
-		accountId string
-		a         AccountAuthenticationMethod
+		accountId         string
+		accountAuthMethId string
+		a                 AccountAuthenticationMethodCreate
 	}
 	tests := []struct {
 		name    string
@@ -202,23 +221,24 @@ func TestAccountAuthenticationsHandler_Create(t *testing.T) {
 			"normal",
 			fields{client: c},
 			args{
-				accountId: "a28707e316df",
-				a: AccountAuthenticationMethod{
-					Name: "test1",
-					Type: "saml",
+				accountId:         "a28707e316df",
+				accountAuthMethId: "am28707eb0055",
+				a: AccountAuthenticationMethodCreate{
+					AuthenticationMethodName: "test1",
+					AuthenticationMethodType: "saml",
 				},
 			},
 			&AccountAuthenticationResponse{
 				APIResponse: APIResponse{},
 				AuthenticationMethod: AccountAuthenticationMethod{
-					AccountId:  "a28707e316df",
-					Enabled:    true,
-					Id:         "am28707eb0055",
-					Name:       "test",
-					Type:       "saml",
-					State:      "active",
-					CreateTime: getTime(t),
-					UpdateTime: getTime(t),
+					AccountID:                   "a28707e316df",
+					AuthenticationMethodEnabled: true,
+					AuthenticationMethodName:    "test",
+					AuthenticationMethodType:    "saml",
+					State:                       "active",
+					CreateTime:                  getTime(t),
+					UpdateTime:                  getTime(t),
+					DeleteTime:                  getTime(t),
 				},
 			},
 			false,
@@ -228,9 +248,9 @@ func TestAccountAuthenticationsHandler_Create(t *testing.T) {
 			fields{client: c},
 			args{
 				accountId: "",
-				a: AccountAuthenticationMethod{
-					Name: "test1",
-					Type: "saml",
+				a: AccountAuthenticationMethodCreate{
+					AuthenticationMethodName: "test1",
+					AuthenticationMethodType: "saml",
 				},
 			},
 			nil,
@@ -262,8 +282,9 @@ func TestAccountAuthenticationsHandler_Update(t *testing.T) {
 		client *Client
 	}
 	type args struct {
-		accountId string
-		a         AccountAuthenticationMethod
+		accountId         string
+		accountAuthMethId string
+		a                 AccountAuthenticationMethodUpdate
 	}
 	tests := []struct {
 		name    string
@@ -276,29 +297,21 @@ func TestAccountAuthenticationsHandler_Update(t *testing.T) {
 			"normal",
 			fields{client: c},
 			args{
-				accountId: "a28707e316df",
-				a: AccountAuthenticationMethod{
-					AccountId:  "a28707e316df",
-					Enabled:    true,
-					Id:         "am28707eb0055",
-					Name:       "test",
-					Type:       "saml",
-					State:      "active",
-					CreateTime: getTime(t),
-					UpdateTime: getTime(t),
+				accountId:         "a28707e316df",
+				accountAuthMethId: "am28707eb0055",
+				a: AccountAuthenticationMethodUpdate{
+					AuthenticationMethodEnabled: true,
+					AuthenticationMethodName:    "test",
 				},
 			},
 			&AccountAuthenticationResponse{
 				APIResponse: APIResponse{},
 				AuthenticationMethod: AccountAuthenticationMethod{
-					AccountId:  "a28707e316df",
-					Enabled:    true,
-					Id:         "am28707eb0055",
-					Name:       "test",
-					Type:       "saml",
+					AccountID:  "a28707e316df",
 					State:      "active",
 					CreateTime: getTime(t),
 					UpdateTime: getTime(t),
+					DeleteTime: getTime(t),
 				},
 			},
 			false,
@@ -307,16 +320,11 @@ func TestAccountAuthenticationsHandler_Update(t *testing.T) {
 			"empty-account-id",
 			fields{client: c},
 			args{
-				accountId: "",
-				a: AccountAuthenticationMethod{
-					AccountId:  "a28707e316df",
-					Enabled:    true,
-					Id:         "am28707eb0055",
-					Name:       "test",
-					Type:       "saml",
-					State:      "active",
-					CreateTime: getTime(t),
-					UpdateTime: getTime(t),
+				accountId:         "",
+				accountAuthMethId: "am28707eb0055",
+				a: AccountAuthenticationMethodUpdate{
+					AuthenticationMethodEnabled: true,
+					AuthenticationMethodName:    "test",
 				},
 			},
 			nil,
@@ -326,16 +334,11 @@ func TestAccountAuthenticationsHandler_Update(t *testing.T) {
 			"empty-id",
 			fields{client: c},
 			args{
-				accountId: "a28707e316df",
-				a: AccountAuthenticationMethod{
-					AccountId:  "a28707e316df",
-					Enabled:    true,
-					Id:         "",
-					Name:       "test",
-					Type:       "saml",
-					State:      "active",
-					CreateTime: getTime(t),
-					UpdateTime: getTime(t),
+				accountId:         "a28707e316df",
+				accountAuthMethId: "",
+				a: AccountAuthenticationMethodUpdate{
+					AuthenticationMethodEnabled: true,
+					AuthenticationMethodName:    "test",
 				},
 			},
 			nil,
@@ -347,7 +350,7 @@ func TestAccountAuthenticationsHandler_Update(t *testing.T) {
 			h := AccountAuthenticationsHandler{
 				client: tt.fields.client,
 			}
-			got, err := h.Update(tt.args.accountId, tt.args.a)
+			got, err := h.Update(tt.args.accountId, tt.args.accountAuthMethId, tt.args.a)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Update() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -443,14 +446,14 @@ func TestAccountAuthenticationsHandler_Get(t *testing.T) {
 			&AccountAuthenticationResponse{
 				APIResponse: APIResponse{},
 				AuthenticationMethod: AccountAuthenticationMethod{
-					AccountId:  "a28707e316df",
-					Enabled:    true,
-					Id:         "am28707eb0055",
-					Name:       "test",
-					Type:       "saml",
-					State:      "active",
-					CreateTime: getTime(t),
-					UpdateTime: getTime(t),
+					AccountID:                   "a28707e316df",
+					AuthenticationMethodEnabled: true,
+					AuthenticationMethodName:    "test",
+					AuthenticationMethodType:    "saml",
+					State:                       "active",
+					CreateTime:                  getTime(t),
+					UpdateTime:                  getTime(t),
+					DeleteTime:                  getTime(t),
 				},
 			},
 			false,

--- a/accounts_acc_test.go
+++ b/accounts_acc_test.go
@@ -151,15 +151,15 @@ var _ = Describe("Accounts", func() {
 		})
 
 		It("AccountAuthentications  add new one", func() {
-			resp, errL := client.AccountAuthentications.Create(account.Account.Id, AccountAuthenticationMethod{
-				Name: "test-auth",
-				Type: "saml",
+			resp, errL := client.AccountAuthentications.Create(account.Account.Id, AccountAuthenticationMethodCreate{
+				AuthenticationMethodName: "test-auth",
+				AuthenticationMethodType: "saml",
 			})
 			Expect(errL).NotTo(HaveOccurred())
-			Expect(resp.AuthenticationMethod.Id).NotTo(BeEmpty())
-			Expect(resp.AuthenticationMethod.SAMLMetadataUrl).NotTo(BeEmpty())
-			Expect(resp.AuthenticationMethod.SAMLAcsUrl).NotTo(BeEmpty())
-			Expect(resp.AuthenticationMethod.AccountId).To(Equal(account.Account.Id))
+			Expect(resp.AuthenticationMethod.AuthenticationMethodID).NotTo(BeEmpty())
+			Expect(resp.AuthenticationMethod.SAMLMetadataURL).NotTo(BeEmpty())
+			Expect(resp.AuthenticationMethod.SAMLAcsURL).NotTo(BeEmpty())
+			Expect(resp.AuthenticationMethod.AccountID).To(Equal(account.Account.Id))
 			Expect(resp.APIResponse.Message).To(BeEmpty())
 			Expect(resp.APIResponse.Errors).To(BeEmpty())
 		})

--- a/kafka_connector.go
+++ b/kafka_connector.go
@@ -152,7 +152,7 @@ func (h *KafkaConnectorsHandler) Status(project, service, name string) (*KafkaCo
 	return &rsp, nil
 }
 
-// Update updates a Kafka Connector configuration by Connector Name
+// Update updates a Kafka Connector configuration by Connector AuthenticationMethodName
 func (h *KafkaConnectorsHandler) Update(project, service, name string, c KafkaConnectorConfig) (*KafkaConnectorResponse, error) {
 	path := buildPath("project", project, "service", service, "connectors", name)
 	bts, err := h.client.doPutRequest(path, c)


### PR DESCRIPTION
Currently AccountAuthenticationMethod struct has all available fields for request and response objects for all http methods. 
Some fields do not support update: authentication_method_id, authentication_method_type. They should not be sent by client because serves does not expect additional fields. 
Some fields do not exist in update response (at least).
https://api.aiven.io/doc/#operation/AccountAuthenticationMethodUpdate

This request adds separate structs for update method request and response.