### PR TITLE
fix GetVPCPeeringWithResourceGroup, set peerResourceGroup optional

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,14 @@ go 1.18
 require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
+	github.com/stretchr/testify v1.5.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
@@ -28,8 +29,10 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/vpc.go
+++ b/vpc.go
@@ -19,7 +19,7 @@ type (
 		PeerAzureTenantId        string                  `json:"peer_azure_tenant_id,omitempty"`
 		UserPeerNetworkCIDRs     []string                `json:"user_peer_network_cidrs,omitempty"`
 		VPCPeeringConnectionType string                  `json:"vpc_peering_connection_type,omitempty"`
-		PeerResourceGroup        string                  `json:"peer_resource_group,omitempty"`
+		PeerResourceGroup        *string                 `json:"peer_resource_group,omitempty"`
 	}
 
 	// VPC holds parameters associated with a Virtual Private Cloud

--- a/vpc_peering_connection_test.go
+++ b/vpc_peering_connection_test.go
@@ -1,0 +1,54 @@
+package aiven
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TesteqStrPointers(t *testing.T) {
+	foo := "foo"
+	bar := "bar"
+	cases := []struct {
+		a, b     *string
+		expected bool
+	}{
+		{
+			a:        &foo,
+			b:        &foo,
+			expected: true,
+		},
+		{
+			a:        nil,
+			b:        nil,
+			expected: true,
+		},
+		{
+			a:        &foo,
+			b:        &bar,
+			expected: false,
+		},
+		{
+			a:        &bar,
+			b:        &foo,
+			expected: false,
+		},
+		{
+			a:        &foo,
+			b:        nil,
+			expected: false,
+		},
+		{
+			a:        nil,
+			b:        &foo,
+			expected: false,
+		},
+	}
+
+	for i, o := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			assert.Equal(t, eqStrPointers(o.a, o.b), o.expected)
+		})
+	}
+}


### PR DESCRIPTION
peerResourceGroup is [optional](https://github.com/aiven/aiven-client/blob/e48db8a3ebdac4af66acd995e324d5c56434828a/aiven/client/client.py#L1284) and acts as additional filter
