### PR TITLE
feat(clickhouse): current queries handler

### DIFF
--- a/clickhouse_query.go
+++ b/clickhouse_query.go
@@ -22,9 +22,37 @@ type (
 		Meta []ClickhouseQueryColumnMeta
 		Data []interface{}
 	}
+
+	ClickhouseCurrentQuery struct {
+		ClientName string  `json:"client_name"`
+		Database   string  `json:"database"`
+		Elapsed    float64 `json:"elapsed"`
+		Query      string  `json:"query"`
+		User       string  `json:"user"`
+	}
+
+	// ClickhouseCurrentQueriesResponse aiven go-client clickhouse current queries response
+	ClickhouseCurrentQueriesResponse struct {
+		APIResponse
+		Queries []ClickhouseCurrentQuery
+	}
 )
 
-// Create creates a ClickHouse job
+// CurrentQueries list current queries
+func (h *ClickhouseQueryHandler) CurrentQueries(project, service string) (*ClickhouseCurrentQueriesResponse, error) {
+	path := buildPath("project", project, "service", service, "clickhouse", "query")
+	bts, err := h.client.doGetRequest(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var r ClickhouseCurrentQueriesResponse
+	errR := checkAPIResponse(bts, &r)
+
+	return &r, errR
+}
+
+// Query creates a ClickHouse job
 func (h *ClickhouseQueryHandler) Query(project, service, database, query string) (*ClickhouseQueryResponse, error) {
 	path := buildPath("project", project, "service", service, "clickhouse", "query")
 	bts, err := h.client.doPostRequest(path, ClickhouseQueryRequest{

--- a/clickhouse_user.go
+++ b/clickhouse_user.go
@@ -128,7 +128,7 @@ func (h *ClickhouseUserHandler) ResetPassword(project, service, uuid, password s
 
 	type PassResponse struct {
 		APIResponse
-		Password string `json:"name"`
+		Password string `json:"password"`
 	}
 
 	var r PassResponse


### PR DESCRIPTION
- Handle Clikhouse current queries API
- Clickhouse reset password API return a json with the field "password" but client tried to unmarshal in go struct with the json tag "name", so the client didn't return the new password. Fixed by replacing json tag.