### PR TITLE
feat: Implement Kafka quota

### DIFF
--- a/client.go
+++ b/client.go
@@ -65,6 +65,7 @@ type Client struct {
 	KafkaMirrorMakerReplicationFlow *MirrorMakerReplicationFlowHandler
 	ElasticsearchACLs               *ElasticSearchACLsHandler
 	KafkaTopics                     *KafkaTopicsHandler
+	KafkaQuotas                     *KafkaQuotasHandler
 	VPCs                            *VPCsHandler
 	VPCPeeringConnections           *VPCPeeringConnectionsHandler
 	Accounts                        *AccountsHandler

--- a/kafka_quota.go
+++ b/kafka_quota.go
@@ -1,0 +1,79 @@
+package aiven
+
+import "net/url"
+
+type (
+	KafkaQuota struct {
+		User              string `json:"user"`
+		ClientId          string `json:"client-id"`
+		ConsumerByteRate  int    `json:"consumer_byte_rate"`
+		ProducerByteRate  int    `json:"producer_byte_rate"`
+		RequestPercentage int    `json:"request_percentage"`
+	}
+	KafkaQuotasHandler struct {
+		client *Client
+	}
+	DeleteKafkaQuotaRequest struct {
+		User     string `json:"user"`
+		ClientId string `json:"client-id"`
+	}
+	KafkaQuotasResponse struct {
+		APIResponse
+		Quotas []*KafkaQuota `json:"quotas"`
+	}
+)
+
+// Create creates a specific kafka quota.
+func (h *KafkaQuotasHandler) Create(project, service string, req KafkaQuota) error {
+	path := buildPath("project", project, "service", service, "quota")
+	bts, err := h.client.doPostRequest(path, req)
+	if err != nil {
+		return err
+	}
+
+	return checkAPIResponse(bts, nil)
+}
+
+// Update update a specific kafka quota.
+func (h *KafkaQuotasHandler) Update(project, service string, req KafkaQuota) error {
+	return h.Create(project, service, req)
+}
+
+// List lists all the kafka quota.
+func (h *KafkaQuotasHandler) List(project, service string) ([]*KafkaQuota, error) {
+	path := buildPath("project", project, "service", service, "quotas")
+	bts, err := h.client.doGetRequest(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var r KafkaQuotasResponse
+	errR := checkAPIResponse(bts, &r)
+
+	return r.Quotas, errR
+}
+
+// Delete deletes a specific kafka topic.
+func (h *KafkaQuotasHandler) Delete(project, service string, req DeleteKafkaQuotaRequest) error {
+	path := buildPath("project", project, "service", service, "quota")
+
+	// Create a new query parameters map
+	queryParams := make(url.Values)
+
+	// Add the user parameter to the query if it is set
+	if req.User != "" {
+		queryParams.Set("user", url.QueryEscape(req.User))
+	}
+
+	// Add the client ID parameter to the query if it is set
+	if req.ClientId != "" {
+		queryParams.Set("client-id", url.QueryEscape(req.ClientId))
+	}
+
+	bts, err := h.client.doDeleteRequest(path+"?"+queryParams.Encode(), nil)
+	if err != nil {
+		return err
+	}
+
+	return checkAPIResponse(bts, nil)
+}

--- a/kafka_quota_acc_test.go
+++ b/kafka_quota_acc_test.go
@@ -1,0 +1,171 @@
+package aiven
+
+import (
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Kafka Quota", func() {
+	var (
+		projectName string
+		project     *Project
+		err         error
+	)
+
+	Context("Kafka Quota CRUD", func() {
+		It("should not error", func() {
+			projectName = os.Getenv("AIVEN_PROJECT_NAME")
+			project, err = client.Projects.Get(projectName)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should populate fields properly", func() {
+			Expect(project).NotTo(BeNil())
+
+			if project != nil {
+				Expect(project.Name).NotTo(BeEmpty())
+			}
+		})
+
+		// kafka service
+		var (
+			serviceName string
+			service     *Service
+			errS        error
+		)
+
+		It("creating service", func() {
+			serviceName = "test-acc-kafka-quota-sr-" + strconv.Itoa(rand.Int())
+			service, errS = client.Services.Create(projectName, CreateServiceRequest{
+				Cloud:        "google-europe-west1",
+				Plan:         "business-4",
+				ProjectVPCID: nil,
+				ServiceName:  serviceName,
+				ServiceType:  "kafka",
+			})
+		})
+
+		It("should not error", func() {
+			Expect(errS).NotTo(HaveOccurred())
+		})
+
+		It("should populate fields properly", func() {
+			Expect(service).NotTo(BeNil())
+
+			if service != nil {
+				Expect(service.Name).NotTo(BeEmpty())
+				Expect(service.Plan).NotTo(BeEmpty())
+				Expect(service.Type).Should(Equal("kafka"))
+
+				Eventually(func() string {
+					service, _ = client.Services.Get(projectName, serviceName)
+					return service.State
+				}, 25*time.Minute, 1*time.Minute).Should(Equal("RUNNING"))
+			}
+		})
+
+		// kafka topic
+		var (
+			errC          error
+			quotaUserName string
+		)
+		quotaUserName = "test1"
+
+		It("create kafka quota", func() {
+			time.Sleep(10 * time.Second)
+			errC = client.KafkaQuotas.Create(projectName, serviceName, KafkaQuota{
+				User:              quotaUserName,
+				ClientId:          "",
+				ConsumerByteRate:  42,
+				ProducerByteRate:  43,
+				RequestPercentage: 44,
+			})
+
+			Eventually(func() string {
+				quotas, _ := client.KafkaQuotas.List(projectName, serviceName)
+
+				if quotas != nil {
+					for _, quota := range quotas {
+						if quota.User == quotaUserName {
+							return quota.User
+						}
+					}
+					return ""
+				}
+
+				return ""
+			}, 25*time.Minute, 1*time.Minute).Should(Equal("test1"))
+		})
+
+		It("should not error kafka quota with config", func() {
+			Expect(errC).NotTo(HaveOccurred())
+		})
+
+		It("should populate fields properly", func() {
+			quotas, errQ := client.KafkaQuotas.List(projectName, serviceName)
+			var foundQuota *KafkaQuota
+			if quotas != nil {
+				for _, quota := range quotas {
+					if quota.User == quotaUserName {
+						foundQuota = quota
+					}
+				}
+			}
+			Expect(errQ).NotTo(HaveOccurred())
+
+			if foundQuota != nil {
+				Expect(foundQuota.User).To(Equal("test1"))
+				Expect(foundQuota.ClientId).To(BeEmpty())
+				Expect(foundQuota.RequestPercentage).To(Equal(44))
+				Expect(foundQuota.ConsumerByteRate).To(Equal(42))
+				Expect(foundQuota.ProducerByteRate).To(Equal(43))
+			}
+		})
+
+		It("should update topic config", func() {
+
+			errU := client.KafkaQuotas.Update(projectName, serviceName, KafkaQuota{
+				User:              quotaUserName,
+				ClientId:          "",
+				ConsumerByteRate:  45,
+				ProducerByteRate:  46,
+				RequestPercentage: 47,
+			})
+			Expect(errU).NotTo(HaveOccurred())
+
+			quotas, errQ := client.KafkaQuotas.List(projectName, serviceName)
+			var foundQuota *KafkaQuota
+			if quotas != nil {
+				for _, quota := range quotas {
+					if quota.User == quotaUserName {
+						foundQuota = quota
+					}
+				}
+			}
+			Expect(errQ).NotTo(HaveOccurred())
+			Expect(foundQuota).NotTo(BeNil())
+
+			if foundQuota != nil {
+				Expect(foundQuota.RequestPercentage).To(Equal(47))
+				Expect(foundQuota.ConsumerByteRate).To(Equal(45))
+				Expect(foundQuota.ProducerByteRate).To(Equal(46))
+			}
+		})
+
+		It("delete Kafka Topic and Kafka service", func() {
+			if errD := client.KafkaQuotas.Delete(projectName, serviceName, DeleteKafkaQuotaRequest{User: quotaUserName, ClientId: ""}); errD != nil {
+				Fail("cannot delete kafka quota" + errD.Error())
+			}
+
+			if errD := client.Services.Delete(projectName, serviceName); errD != nil {
+				Fail("cannot delete service:" + errD.Error())
+			}
+		})
+	})
+})


### PR DESCRIPTION
Kafka quotas are now supported in Aiven API, adding support for the go client
Following: 
https://api.aiven.io/doc/#tag/Service:_Kafka/operation/ServiceKafkaQuotaCreate