### PR TITLE
chore: compatibility as a go mod dependency

### DIFF
--- a/examples/accounts/main.go
+++ b/examples/accounts/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	client "github.com/aiven/aiven-go-client"
+	client "github.com/aiven/aiven-go-client/v2"
 )
 
 func main() {

--- a/examples/elasticsearch/main.go
+++ b/examples/elasticsearch/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	client "github.com/aiven/aiven-go-client"
+	client "github.com/aiven/aiven-go-client/v2"
 )
 
 func main() {

--- a/examples/kafka_connectors/main.go
+++ b/examples/kafka_connectors/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	client "github.com/aiven/aiven-go-client"
+	client "github.com/aiven/aiven-go-client/v2"
 )
 
 func main() {

--- a/examples/kafka_schemas/main.go
+++ b/examples/kafka_schemas/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	client "github.com/aiven/aiven-go-client"
+	client "github.com/aiven/aiven-go-client/v2"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/aiven/aiven-go-client
+module github.com/aiven/aiven-go-client/v2
 
-go 1.18
+go 1.21
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2


### PR DESCRIPTION
currently, it's not possible to install `aiven-go-client` v2 as a dependency because of the following error:

```log
go: github.com/aiven/aiven-go-client@v2.0.0-rc.4: invalid version: module contains a go.mod file, so module path must match major version ("github.com/aiven/aiven-go-client/v2")
```

this PR addresses this issue, see https://donatstudios.com/Go-v2-Modules for more information
