### PR TITLE
fix(kafkatopic): temporarily disable local_retention_* fields

### DIFF
--- a/kafka_topic.go
+++ b/kafka_topic.go
@@ -30,8 +30,8 @@ type (
 		SegmentMs                       *int64   `json:"segment_ms,omitempty"`
 		UncleanLeaderElectionEnable     *bool    `json:"unclean_leader_election_enable,omitempty"`
 		RemoteStorageEnable             *bool    `json:"remote_storage_enable,omitempty"`
-		LocalRetentionBytes             *int64   `json:"local_retention_bytes,omitempty"`
-		LocalRetentionMs                *int64   `json:"local_retention_ms,omitempty"`
+		//LocalRetentionBytes             *int64   `json:"local_retention_bytes,omitempty"`
+		//LocalRetentionMs                *int64   `json:"local_retention_ms,omitempty"`
 	}
 
 	// KafkaTopicConfigResponse represents a Kafka Topic Config on Aiven.
@@ -61,9 +61,9 @@ type (
 		SegmentMs                       KafkaTopicConfigResponseInt    `json:"segment_ms,omitempty"`
 		UncleanLeaderElectionEnable     KafkaTopicConfigResponseBool   `json:"unclean_leader_election_enable,omitempty"`
 		RemoteStorageEnable             KafkaTopicConfigResponseBool   `json:"remote_storage_enable,omitempty"`
-		LocalRetentionBytes             KafkaTopicConfigResponseInt    `json:"local_retention_bytes,omitempty"`
-		LocalRetentionMs                KafkaTopicConfigResponseInt    `json:"local_retention_ms,omitempty"`
-		Tags                            []KafkaTopicTag                `json:"tags,omitempty"`
+		//LocalRetentionBytes             KafkaTopicConfigResponseInt    `json:"local_retention_bytes,omitempty"`
+		//LocalRetentionMs                KafkaTopicConfigResponseInt    `json:"local_retention_ms,omitempty"`
+		Tags []KafkaTopicTag `json:"tags,omitempty"`
 	}
 
 	KafkaTopicTag struct {


### PR DESCRIPTION
temporarily disables `local_retention_*` fields in `kafkatopic` as a hotfix
