### PR TITLE
feat: add `config_properties_exclude` to mirrormaker ReplicationFlow

### DIFF
--- a/mirrormaker_replication_flow.go
+++ b/mirrormaker_replication_flow.go
@@ -23,6 +23,7 @@ type (
 		Topics                          []string `json:"topics,omitempty"`
 		TopicsBlacklist                 []string `json:"topics.blacklist,omitempty"`
 		ReplicationFactor               *int     `json:"replication_factor,omitempty"`
+		ConfigPropertiesExclude         string   `json:"config_properties_exclude,omitempty"`
 	}
 
 	// MirrorMakerReplicationFlowRequest request used to create a Kafka MirrorMaker 2


### PR DESCRIPTION
Adds ReplicationFlow `config_properties_exclude`