### PR TITLE
feat: Add support for description and owner for topics

### DIFF
--- a/kafka_topic.go
+++ b/kafka_topic.go
@@ -122,18 +122,22 @@ type (
 		TopicName             string                   `json:"topic_name"`
 		Config                KafkaTopicConfigResponse `json:"config"`
 		Tags                  []KafkaTopicTag          `json:"tags,omitempty"`
+		TopicDescription	  *string				   `json:"topic_description,omitempty"`
+		OwnerUserGroupId	  *string				   `json:"owner_user_group_id,omitempty"`
 	}
 
 	// KafkaListTopic represents kafka list topic model on Aiven.
 	KafkaListTopic struct {
-		CleanupPolicy         string `json:"cleanup_policy"`
-		MinimumInSyncReplicas int    `json:"min_insync_replicas"`
-		Partitions            int    `json:"partitions"`
-		Replication           int    `json:"replication"`
-		RetentionBytes        int    `json:"retention_bytes"`
-		RetentionHours        *int64 `json:"retention_hours,omitempty"`
-		State                 string `json:"state"`
-		TopicName             string `json:"topic_name"`
+		CleanupPolicy         string  `json:"cleanup_policy"`
+		MinimumInSyncReplicas int     `json:"min_insync_replicas"`
+		Partitions            int     `json:"partitions"`
+		Replication           int     `json:"replication"`
+		RetentionBytes        int     `json:"retention_bytes"`
+		RetentionHours        *int64  `json:"retention_hours,omitempty"`
+		State                 string  `json:"state"`
+		TopicName             string  `json:"topic_name"`
+		TopicDescription	  *string `json:"topic_description,omitempty"`
+		OwnerUserGroupId	  *string `json:"owner_user_group_id,omitempty"`
 	}
 
 	// Partition represents a Kafka partition.
@@ -169,6 +173,8 @@ type (
 		TopicName             string           `json:"topic_name"`
 		Config                KafkaTopicConfig `json:"config"`
 		Tags                  []KafkaTopicTag  `json:"tags,omitempty"`
+		TopicDescription	  *string		   `json:"topic_description,omitempty"`
+		OwnerUserGroupId	  *string		   `json:"owner_user_group_id,omitempty"`
 	}
 
 	// UpdateKafkaTopicRequest are the parameters used to update a kafka topic.
@@ -180,6 +186,8 @@ type (
 		RetentionHours        *int             `json:"retention_hours,omitempty"`
 		Config                KafkaTopicConfig `json:"config"`
 		Tags                  []KafkaTopicTag  `json:"tags,omitempty"`
+		TopicDescription	  *string		   `json:"topic_description,omitempty"`
+		OwnerUserGroupId	  *string		   `json:"owner_user_group_id,omitempty"`
 	}
 
 	// KafkaTopicResponse is the response for Kafka Topic requests.

--- a/kafka_topic_acc_test.go
+++ b/kafka_topic_acc_test.go
@@ -75,12 +75,14 @@ var _ = Describe("Kafka Topic", func() {
 
 		// kafka topic
 		var (
-			errC            error
-			topicName       string
-			segmentJitterMs int64
+			errC              error
+			topicName         string
+			segmentJitterMs   int64
 		)
 		segmentJitterMs = 10
 		topicName = "test1"
+		topicDescription := "test-description"
+		ownerUserGroupId := "org22ba494e096"
 
 		It("create kafka topic", func() {
 			time.Sleep(10 * time.Second)
@@ -96,6 +98,8 @@ var _ = Describe("Kafka Topic", func() {
 						Value: "tag1-value",
 					},
 				},
+				TopicDescription: &topicDescription,
+				OwnerUserGroupId: &ownerUserGroupId,
 			})
 
 			Eventually(func() string {
@@ -123,13 +127,19 @@ var _ = Describe("Kafka Topic", func() {
 				Expect(t.Tags).NotTo(BeEmpty())
 				Expect(t.Tags[0].Key).To(Equal("tag1-key"))
 				Expect(t.Tags[0].Value).To(Equal("tag1-value"))
+				Expect(t.TopicDescription).To(Equal(topicDescription))
+				Expect(t.OwnerUserGroupId).To(Equal(ownerUserGroupId))
 			}
 		})
 
 		It("should update topic config", func() {
 			var uncleanLeaderElectionEnable = true
+			newTopicDescription := "test-description-2"
+			newOwnerUserGroupId := "org22ba494e097"
 
 			errU := client.KafkaTopics.Update(ctx, projectName, serviceName, topicName, UpdateKafkaTopicRequest{
+				TopicDescription: &newTopicDescription,
+				OwnerUserGroupId: &newOwnerUserGroupId,
 				Config: KafkaTopicConfig{
 					UncleanLeaderElectionEnable: &uncleanLeaderElectionEnable,
 				},
@@ -154,6 +164,8 @@ var _ = Describe("Kafka Topic", func() {
 				Expect(t2.Config.UncleanLeaderElectionEnable.Value).Should(Equal(true))
 				Expect(t2.Tags).ShouldNot(BeEmpty())
 				Expect(len(t2.Tags)).To(Equal(2))
+				Expect(t2.TopicDescription).To(Equal(newTopicDescription))
+				Expect(t2.OwnerUserGroupId).To(Equal(newOwnerUserGroupId))
 			}
 		})
 
@@ -166,6 +178,9 @@ var _ = Describe("Kafka Topic", func() {
 			Expect(list[0].Config.SegmentJitterMs.Value).To(Equal(segmentJitterMs))
 			Expect(list[0].Tags).NotTo(BeEmpty())
 			Expect(len(list[0].Tags)).To(Equal(2))
+			Expect(list[0].TopicDescription).To(Equal(topicDescription))
+			Expect(list[0].OwnerUserGroupId).To(Equal(ownerUserGroupId))
+			
 		})
 
 		It("delete Kafka Topic and Kafka service", func() {


### PR DESCRIPTION
Make it possible to provide topic_description and owner_user_group_id when creating and updating topic. Also adds it to the schema.

