### PR TITLE
fix: remove `Powered` field from from `Service` type (#365)

### DIFF
--- a/service.go
+++ b/service.go
@@ -32,7 +32,6 @@ type (
 		MaintenanceWindow     MaintenanceWindow         `json:"maintenance"`
 		Integrations          []*ServiceIntegration     `json:"service_integrations"`
 		Components            []*ServiceComponents      `json:"components"`
-		Powered               bool                      `json:"powered"`
 		NodeStates            []*NodeState              `json:"node_states"`
 		DiskSpaceMB           int                       `json:"disk_space_mb"`
 		Features              ServiceFeatures           `json:"features"`


### PR DESCRIPTION
[ServiceGet](https://api.aiven.io/doc/#tag/Service/operation/ServiceGet) response doesn't contain powered. Previously, the field defaulted to `false`.

To verify the service state, use the `State` field. When the service is powered off, state is "POWEROFF".