### PR TITLE
fix: avoid leaking response body in API error messages

### DIFF
--- a/client.go
+++ b/client.go
@@ -312,6 +312,14 @@ func (c *Client) doV2DeleteRequest(ctx context.Context, endpoint string, req int
 	return c.doRequest(ctx, "DELETE", endpoint, req, 2)
 }
 
+// apiErrorResponse is the safe subset of an Aiven failed response.
+// Other fields are dropped because the body may contain credentials.
+// See https://api.aiven.io/doc/#section/Responses/Failed-responses
+// and https://github.com/aiven/aiven-go-client/issues/369
+type apiErrorResponse struct {
+	Message string `json:"message"`
+}
+
 func (c *Client) doRequest(ctx context.Context, method, uri string, body interface{}, apiVersion int) ([]byte, error) {
 	var bts []byte
 	if body != nil {
@@ -368,8 +376,25 @@ func (c *Client) doRequest(ctx context.Context, method, uri string, body interfa
 	}()
 
 	responseBody, err := io.ReadAll(rsp.Body)
-	if err != nil || rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
-		return nil, Error{Message: string(responseBody), Status: rsp.StatusCode}
+	if err != nil {
+		return nil, Error{
+			Message: fmt.Sprintf("failed to read response body: %s", err),
+			Status:  rsp.StatusCode,
+		}
+	}
+	if rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
+		// Only surface the "message" field; the body may contain credentials.
+		// The upstream API "message" must be returned verbatim because
+		// external callers rely on its exact value to classify errors.
+		var errBody apiErrorResponse
+		err := json.Unmarshal(responseBody, &errBody)
+		if err != nil {
+			return nil, Error{
+				Message: "failed to parse error response",
+				Status:  rsp.StatusCode,
+			}
+		}
+		return nil, Error{Message: errBody.Message, Status: rsp.StatusCode}
 	}
 	return responseBody, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClient_Init(t *testing.T) {
@@ -130,6 +132,81 @@ func TestIsServiceLagError(t *testing.T) {
 			assert.Equal(t, opt.expected, isServiceLagError(opt.method, opt.body))
 		})
 	}
+}
+
+// TestDoRequest_ReadErrorDoesNotLeakBody is a regression test for
+// https://github.com/aiven/aiven-go-client/issues/369: when io.ReadAll fails
+// while reading the response body, any bytes already read (which may include
+// service user credentials) must not be included in the returned error.
+func TestDoRequest_ReadErrorDoesNotLeakBody(t *testing.T) {
+	const secret = "SUPER-SECRET-CREDENTIAL"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Advertise a body larger than we actually send, then forcibly close
+		// the underlying connection so io.ReadAll on the client returns an
+		// "unexpected EOF" error after partially reading the body.
+		w.Header().Set("Content-Length", "10000")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(secret))
+
+		hj, ok := w.(http.Hijacker)
+		require.True(t, ok, "expected http.Hijacker support")
+		conn, _, err := hj.Hijack()
+		require.NoError(t, err)
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	// Override the package-level apiUrl to point at the test server.
+	origAPIURL := apiUrl
+	apiUrl = server.URL + "/v1"
+	defer func() { apiUrl = origAPIURL }()
+
+	// Use a plain http.Client so retryablehttp does not retry the read error.
+	c := &Client{Client: &http.Client{}}
+
+	_, err := c.doGetRequest(context.Background(), "/anything", nil)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), secret,
+		"response body must not be included in read-error message")
+}
+
+// TestDoRequest_NonOKDoesNotLeakBody verifies that on a non-2xx response the
+// returned Error only contains the JSON "message" field, not the full body
+// (which may contain sensitive data such as service user credentials).
+// Regression test for https://github.com/aiven/aiven-go-client/issues/369.
+func TestDoRequest_NonOKDoesNotLeakBody(t *testing.T) {
+	const (
+		secret  = "SUPER-SECRET-CREDENTIAL"
+		message = "service does not exist"
+	)
+	body := fmt.Sprintf(
+		`{"message":%q,"services":[{"username":"u","password":%q}]}`,
+		message, secret,
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	origAPIURL := apiUrl
+	apiUrl = server.URL + "/v1"
+	defer func() { apiUrl = origAPIURL }()
+
+	c := &Client{Client: &http.Client{}}
+
+	_, err := c.doGetRequest(context.Background(), "/anything", nil)
+	require.Error(t, err)
+
+	aerr, ok := err.(Error)
+	require.True(t, ok, "expected aiven.Error, got %T", err)
+	assert.Equal(t, http.StatusBadRequest, aerr.Status)
+	assert.Equal(t, message, aerr.Message)
+	assert.NotContains(t, err.Error(), secret,
+		"response body must not be included in API error")
 }
 
 func TestIsUserError(t *testing.T) {


### PR DESCRIPTION
Resolves NEX-2480, #369.

Decode only the JSON "message" field from failed responses into Error.Message instead of returning the raw body, which may contain service user credentials. Surface io.ReadAll and json.Unmarshal failures explicitly without including any body bytes.